### PR TITLE
Fixes

### DIFF
--- a/love-loader.lua
+++ b/love-loader.lua
@@ -177,9 +177,10 @@ else
       if loader.thread:isRunning() then
         if resourceBeingLoaded then
           getResourceFromThreadIfAvailable()
-          endThreadIfAllLoaded()
         elseif #pending > 0 then
           requestNewResourceToThread()
+        else
+          endThreadIfAllLoaded()
         end
       else
         local errorMessage = loader.thread:getError()


### PR DESCRIPTION
Two fixes.

The one about changing the way that we get errors, I should have noticed in testing but because of the way I changed the update function to only enter into `getResourceFromThreadIfAvailable` if it was running, we weren't getting errors from the thread anymore.

The other one, I don't have an old love2d binary to test this with but I think that this might be an old issue. If you never put anything in the pending queue, `resourceBeingLoaded` doesn't get initialized and so neither of the conditions in `update` are ever true and the thread never finishes and exits.
