### PR TITLE
 Remove reference to thread from loader after completion.

### DIFF
--- a/love-loader.lua
+++ b/love-loader.lua
@@ -198,6 +198,7 @@ else
           requestNewResourceToThread()
         else
           endThreadIfAllLoaded()
+          loader.thread = nil
         end
       else
         local errorMessage = loader.thread:getError()


### PR DESCRIPTION
We’ve signalled the loading thread to shut down but it’s possible that we have another update tick before it manages to do so. We’re already checking that `loader.thread` exists so removing the reference to that thread is an effective guard against a slow thread ending.

If would be better to remove the condition that creates this race in the first place but this should be an adequate stopgap.

This fixes #8.