### PR TITLE
Static sources

### DIFF
--- a/love-loader.lua
+++ b/love-loader.lua
@@ -42,11 +42,11 @@ local resourceKinds = {
       return love.graphics.newImage(data)
     end
   },
-  source = {
-    requestKey  = "sourcePath",
-    resourceKey = "source",
+  staticSource = {
+    requestKey  = "staticPath",
+    resourceKey = "staticSource",
     constructor = function(path)
-      return love.audio.newSource(path)
+      return love.audio.newSource(path, "static")
     end
   },
   font = {
@@ -75,9 +75,9 @@ local resourceKinds = {
       return love.graphics.newFont(glyphs,data)
     end
   },
-  stream = {
+  streamSource = {
     requestKey  = "streamPath",
-    resourceKey = "stream",
+    resourceKey = "streamSource",
     constructor = function(path)
       return love.audio.newSource(path, "stream")
     end
@@ -180,7 +180,7 @@ else
   end
 
   function loader.newSource(holder, key, path, sourceType)
-    local kind = (sourceType == 'stream' and 'stream' or 'source')
+    local kind = (sourceType == 'static' and 'staticSource' or 'streamSource')
     newResource(kind, holder, key, path)
   end
 


### PR DESCRIPTION
Since the beginning love-loader has supported 2 sourceTypes, `stream` and `source`, there is only one difference between these:
- `stream` maps to [`love.audio.newSource(path, "stream")`](https://github.com/kikito/love-loader/blob/master/love-loader.lua#L82)
- `source` maps to [`love.audio.newSource(path, nil)`](https://github.com/kikito/love-loader/blob/master/love-loader.lua#L49)

In versions before 11.x passing `nil` as second argument made the [SourceType][sourcetype] default to `stream`, so both this variants created `stream` [Sources][source].

In version 11.0 and 11.1 however, the [SourceType][sourcetype] is mandatory and there is no default value.

So instead of having the `source` sourceType (which was the same as stream previously and now breaks in 11.x as seen in issue #22), this PR changes it to `static`, which now maps to [`love.audio.newSource(path, "static")`](https://github.com/Positive07/love-loader/commit/33d533c6765fb8f5c6d0bf9f940a9b47d0917677#diff-b32b919a4d18f86fcae555e1594288cfR49).

PS: Thanks to @flamendless for debugging and reporting the issue

Fixes #22 

[sourcetype]: https://love2d.org/wiki/SourceType
[source]: https://love2d.org/wiki/Source