### PR TITLE
Add support for CompressedImageData

### DIFF
--- a/love-loader.lua
+++ b/love-loader.lua
@@ -37,7 +37,13 @@ local resourceKinds = {
   image = {
     requestKey  = "imagePath",
     resourceKey = "imageData",
-    constructor = love.image.newImageData,
+    constructor = function (path)
+      if love.image.isCompressed(path) then
+        return love.image.newCompressedData(path)
+      else
+        return love.image.newImageData(path)
+      end
+    end,
     postProcess = function(data)
       return love.graphics.newImage(data)
     end
@@ -91,6 +97,11 @@ local resourceKinds = {
     requestKey  = "imageDataPath",
     resourceKey = "rawImageData",
     constructor = love.image.newImageData
+  },
+  compressedData = {
+    requestKey  = "compressedDataPath",
+    resourceKey = "rawCompressedData",
+    constructor = love.image.newCompressedData
   }
 }
 
@@ -190,6 +201,10 @@ else
 
   function loader.newImageData(holder, key, path)
     newResource('imageData', holder, key, path)
+  end
+  
+  function loader.newCompressedData(holder, key, path)
+    newResource('compressedData', holder, key, path)
   end
 
   function loader.start(allLoadedCallback, oneLoadedCallback)


### PR DESCRIPTION
This PR
- Adds `loader.newCompressedData` equivalent to [`love.image.newCompressedData`][newCompressedData]
- Adds support for [CompressedImageData][CompressedImageData] in [loader.newImage][newImage]
- Fixes #17

Note: in order to support both [CompressedImageData][CompressedImageData] and [ImageData][ImageData] a check with [love.image.isCompressed][isCompressed] is needed.

[newCompressedData]: https://love2d.org/wiki/love.image.newCompressedData
[CompressedImageData]: https://love2d.org/wiki/CompressedImageData
[newImage]: https://github.com/kikito/love-loader/blob/master/love-loader.lua#L170L172
[ImageData]: https://love2d.org/wiki/ImageData
[isCompressed]: https://love2d.org/wiki/love.image.isCompressed