### PR TITLE
Fix #25

### DIFF
--- a/love-loader.lua
+++ b/love-loader.lua
@@ -70,8 +70,8 @@ local resourceKinds = {
     end
   },
   BMFont = {
-    requestKey  = "fontPath",
-    resourceKey = "fontData",
+    requestKey  = "fontBMPath",
+    resourceKey = "fontBMData",
     constructor = function(path)
       return love.filesystem.newFileData(path)
     end,


### PR DESCRIPTION
Due to equal ```requestKey``` in both ```font``` and ```BMFont``` kinds, they got same channel. That leads to situation, when resource is post-processed by wrong kind in ```getResourceFromThreadIfAvailable()```