### PR TITLE
Changed method of getting path

### DIFF
--- a/love-loader.lua
+++ b/love-loader.lua
@@ -135,7 +135,7 @@ else
   local callbacks = {}
   local resourceBeingLoaded
 
-  local pathToThisFile = (...):gsub("%.", "/") .. ".lua"
+  local pathToThisFile = debug.getinfo(1).source:match("@?(.*)")
 
   local function shift(t)
     return table.remove(t,1)

--- a/love-loader.lua
+++ b/love-loader.lua
@@ -135,7 +135,10 @@ else
   local callbacks = {}
   local resourceBeingLoaded
 
-  local pathToThisFile = debug.getinfo(1).source:match("@?(.*)")
+  local pathToThisFile = (...):gsub("%.", "/") .. ".lua"
+  if love.filesystem.getInfo(pathToThisFile) == nil and type(debug) == "table" and type(debug.getinfo) == "function" then
+    pathToThisFile = debug.getinfo(1).source:match("@?(.*)")
+  end
 
   local function shift(t)
     return table.remove(t,1)


### PR DESCRIPTION
If the library loading path is changed with something like `love.filesystem.setRequirePath('?.lua;lib/?.lua;lib/?/init.lua;lib/?/?.lua')` then this code will fail: `local pathToThisFile = (...):gsub("%.", "/") .. ".lua"`

It will work if changed to the following. `local pathToThisFile = debug.getinfo(1).source:match("@?(.*)")`

See [this documentation](https://www.lua.org/pil/23.1.html) for information about debug.getinfo.

Note, I believe in Lua 5.2+ `...` in a required file would be the name of the module and the path of the file. However, Love 11 includes Lua 5.1, which means `...` is only the name of the module ([see this](https://stackoverflow.com/questions/21416798/lua-global-variable-containing-path-to-current-file/21419777#21419777)).